### PR TITLE
chore: add wave 2 PR workflow gates

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,26 @@
+name: dependency-review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    steps:
+      - name: skip-unsupported-private-repos
+        if: github.event.repository.private
+        run: echo "Dependency review is skipped on private repositories unless GitHub Advanced Security is enabled."
+      - name: dependency-review
+        if: ${{ !github.event.repository.private }}
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48

--- a/.github/workflows/linked-issue.yml
+++ b/.github/workflows/linked-issue.yml
@@ -1,0 +1,58 @@
+name: linked-issue
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-linked-issue:
+    name: check-linked-issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-linked-issue
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+              event = json.load(handle)
+
+          pull_request = event["pull_request"]
+          actor = event.get("sender", {}).get("login", "")
+          if actor in {"dependabot[bot]", "github-actions[bot]", "renovate[bot]"}:
+              print(f"Automation PR from {actor}; skipping linked issue requirement.")
+              sys.exit(0)
+
+          labels = {label["name"] for label in pull_request.get("labels", [])}
+          if "no-linked-issue-required" in labels:
+              print("Bypass label present; skipping linked issue requirement.")
+              sys.exit(0)
+
+          content = "\n".join(
+              part for part in [pull_request.get("title", ""), pull_request.get("body", "")]
+              if part
+          )
+          patterns = (
+              r"(?<![A-Za-z0-9_])(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+\b",
+              r"https://github\.com/[^/\s]+/[^/\s]+/issues/\d+\b",
+          )
+
+          if any(re.search(pattern, content, re.IGNORECASE) for pattern in patterns):
+              print("Issue reference found in PR title/body.")
+              sys.exit(0)
+
+          print('::error title=Linked issue required::Add an issue reference to the PR title or body (for example, "Closes #123" or "#123"), or apply the "no-linked-issue-required" label.')
+          sys.exit(1)
+          PY

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,51 @@
+name: pr-title
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - name: pr-title
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+              event = json.load(handle)
+
+          pull_request = event["pull_request"]
+          if pull_request.get("draft"):
+              print("Draft PR; skipping title validation until ready for review.")
+              sys.exit(0)
+
+          title = (pull_request.get("title") or "").strip()
+          if not title:
+              print("::error title=PR title required::PR title cannot be empty.")
+              sys.exit(1)
+
+          blocked_patterns = (
+              r"^\s*\[?\s*(?:wip|draft|dnm)\b",
+              r"^\s*do not merge\b",
+          )
+          if any(re.search(pattern, title, re.IGNORECASE) for pattern in blocked_patterns):
+              print('::error title=Invalid PR title::Update the PR title before review. WIP, draft, DNM, and "Do Not Merge" prefixes are not allowed.')
+              sys.exit(1)
+
+          print(f"PR title is valid: {title}")
+          PY


### PR DESCRIPTION
## Summary
- add the standardized dependency review workflow
- add the standardized linked-issue enforcement workflow
- add the standardized PR title workflow with cancel-in-progress concurrency

Closes #20
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/amplifier-core/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
