### PR TITLE
ci: add remaining PR workflow concurrency guards

### DIFF
--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -14,6 +14,10 @@ on:
       - 'python/amplifier_core/_grpc_gen/**'
       - 'crates/amplifier-core/src/generated/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   proto-sync:
     name: Verify Python stubs match proto

--- a/.github/workflows/rust-core-ci.yml
+++ b/.github/workflows/rust-core-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [rust-core, main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rust-tests:
     name: Rust Kernel Tests


### PR DESCRIPTION
Closes #24

## Summary
- add concurrency groups with cancel-in-progress to proto-check.yml
- add concurrency groups with cancel-in-progress to rust-core-ci.yml

## Validation
- parsed workflow YAML and verified every root pull_request workflow now has concurrency + cancel-in-progress
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/amplifier-core/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
